### PR TITLE
Small fixes for DMCE

### DIFF
--- a/dmce-set-profile
+++ b/dmce-set-profile
@@ -134,7 +134,7 @@ while count < len(clines):
                 clines[count] = setProbeOrProlog(clines[count], "dmce-prolog-trace-DX.c")
 
             if "DMCE_PROBE_NBR_OPTIONAL_ELEMENTS" in clines[count]:
-                clines[count] = "DMCE_PROBE_DEFINE:DMCE_PROBE_NBR_OPTIONAL_ELEMENTS 5"
+                clines[count] = "DMCE_PROBE_DEFINE:DMCE_PROBE_NBR_OPTIONAL_ELEMENTS 5\n"
 
             if "DMCE_POST_HOOK" in clines[count]:
                 clines[count] = setProbeOrProlog(clines[count], "dmce-post-hook-null")
@@ -210,7 +210,7 @@ while count < len(clines):
                 clines[count] = setProbeOrProlog(clines[count], "dmce-post-hook-racetrack")
 
         else:
-            print("Unknown profile (please use trace, trace-mc, coverage, racetrack, printf or syslog), abort")
+            print("Unknown profile (please use trace, trace-mc, coverage, heatmap, racetrack, printf or syslog), abort")
             sys.exit(1)
 
 # Modify config folder

--- a/probe-examples/dmce-probe-heatmap.c
+++ b/probe-examples/dmce-probe-heatmap.c
@@ -12,6 +12,12 @@
 #include <sys/syscall.h>
 #include <sys/sysinfo.h>
 
+
+long syscall(long number, ...);
+int on_exit(void (*function)(int , void *), void *arg);
+char *strsignal(int sig);
+
+
 #ifdef DMCE_NBR_OF_PROBES
 #define DMCE_NUM_PROBES DMCE_NBR_OF_PROBES
 #else

--- a/probe-examples/dmce-probe-trace-atexit-DX-CB.c
+++ b/probe-examples/dmce-probe-trace-atexit-DX-CB.c
@@ -17,6 +17,10 @@
 #define DMCE_MAX_HITS DMCE_PROBE_NBR_TRACE_ENTRIES
 #endif
 
+long syscall(long number, ...);
+int on_exit(void (*function)(int , void *), void *arg);
+char *strsignal(int sig);
+
 #define DMCE_TRACE_RINGBUFFER
 #define NBR_STATUS_BITS 1
 

--- a/probe-examples/dmce-probe-trace-atexit-DX-SB.c
+++ b/probe-examples/dmce-probe-trace-atexit-DX-SB.c
@@ -18,6 +18,10 @@
 #define DMCE_MAX_HITS DMCE_PROBE_NBR_TRACE_ENTRIES
 #endif
 
+long syscall(long number, ...);
+int on_exit(void (*function)(int , void *), void *arg);
+char *strsignal(int sig);
+
 #define NBR_STATUS_BITS 1
 
 #ifndef DMCE_PROBE_LOCK_DIR_ENTRY
@@ -58,6 +62,7 @@ extern char *program_invocation_short_name;
 #define dmce_unlikely(x) (x)
 #endif
 #endif
+
 
 #ifdef __cplusplus
 static dmce_probe_entry_t* dmce_buf_p = nullptr;


### PR DESCRIPTION
1. Declarations for on_exit, strsignal, syscall are missing when compiling without some feature test macros enabled. Add these declarations to the probe. 
2. A missing newline for .dmceconfig update. 