### PR TITLE
dmce-set-profile: add newline after includepaths

### DIFF
--- a/bin/dmce-set-profile
+++ b/bin/dmce-set-profile
@@ -106,6 +106,7 @@ while count < len(clines):
             if args.includepaths != '':
                 for path in args.includepaths.split(","):
                     clines[count] = clines[count].rstrip() + " -I" + path
+                clines[count] += "\n"
 
         # Check if register signal handler
         if "DMCE_PROBE_HANDLE_SIGNALS" in clines[count]:


### PR DESCRIPTION
Previously when using the -I option, no newline character was added in .dmceconfig, causing lines to eventually merge