### PR TITLE
Don't spin on FileNotFoundError during dmce-copy-headers

### DIFF
--- a/share/dmce-copy-headers
+++ b/share/dmce-copy-headers
@@ -61,6 +61,9 @@ def parse_file(f, index):
         try:
             fp = open(f, errors="replace")
             open_succeeded = True
+        except FileNotFoundError as exn:
+            includes_array[index] = exn
+            return
         except:
             time.sleep(1)
 
@@ -96,7 +99,9 @@ threads = []
 uniq_includes_array = []
 
 for i in range(len(includes_array)):
-    if includes_array[i] == None:
+    if isinstance(includes_array[i], Exception):
+        raise includes_array[i]
+    elif includes_array[i] is None:
         break
     for include in includes_array[i]:
         if include not in uniq_includes_array:


### PR DESCRIPTION
If trying to open a source file raises a FileNotFoundError, abort with an error message instead of waiting silently and indefinitely.

Solves hangups due to temporary files (e.g. autosaves).