### PR TITLE
Fix dmce-summary-bin --filter not filtering correctly

### DIFF
--- a/bin/dmce-summary-bin
+++ b/bin/dmce-summary-bin
@@ -104,10 +104,10 @@ if filterlimit != None:
      filterfmt="{}:{}-{}"
      for probe in res:
           nselected += probe[4]
-          if nselected >= nlimit:
-               break
           function_line = probe[2]
           print(filterfmt.format(probe[1],function_line_str(probe),probe[2]))
+          if nselected >= nlimit:
+               break
      sys.exit(0)
 
 # find the probes not executed


### PR DESCRIPTION
When using _dmce-summary-bin_ with the _--filter_ option, it more or less always misses one probe that should have been excluded. This is because a _break_ happens after updating the condition but _before_ we print the filter line.

Example using the _"simple"_ program from _dmce-examples_ (with _"--filter 100"_ set for illustrative purposes):

Before any filtering:
![before](https://github.com/PatrikAAberg/dmce/assets/29545130/7f90052c-1c5b-4c47-8400-1fcc133f1279)

After using _"--filter 100"_:
![after](https://github.com/PatrikAAberg/dmce/assets/29545130/ed739696-40e1-42f0-bc10-5af2f5ba1574)

Looking at the output when using _"--filter 100"_ we see that it misses one probe.

Before this fix:
![image](https://github.com/PatrikAAberg/dmce/assets/29545130/403d956e-ab52-481c-ac22-b5ef2cc1482d)

After this fix:
![image](https://github.com/PatrikAAberg/dmce/assets/29545130/b869a08d-4855-457a-8e29-95b5258d157a)

